### PR TITLE
Link with `PXR_LIBRARIES` instead of `usdGeom`

### DIFF
--- a/src/arHttp/CMakeLists.txt
+++ b/src/arHttp/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(${_lib}
   plugInfo.json
 )
 target_link_libraries(${_lib}
-  usdGeom
+  ${PXR_LIBRARIES}
 )
 target_include_directories(${_lib}
   PRIVATE


### PR DESCRIPTION
Hi, compiling arHttp doesn't work for me as-is because I'm using [the Arch Linux USD package](https://archlinux.org/packages/extra/x86_64/usd/) which provides the monolithic usd_ms.so library instead of the individual libraries such as usdGeom. `pxrConfig.cmake` provides a `PXR_LIBRARIES` variable that should be used instead (as far as I know). 